### PR TITLE
Stop doesn't seem to be an error condition as it is set on reads also

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -15,8 +15,6 @@ use hal::blocking::i2c::{Read, Write, WriteRead};
 /// I2C error
 #[derive(Debug)]
 pub enum Error {
-    /// Stop condition detected
-    Stop,
     /// NACK received, i.e. communication not acknowledged by peripheral
     NACK,
     /// Bus error
@@ -63,8 +61,6 @@ macro_rules! busy_wait {
                 return Err(Error::Arbitration);
             } else if isr.nackf().bit_is_set() {
                 return Err(Error::NACK);
-            } else if isr.stopf().bit_is_set() {
-                return Err(Error::Stop);
             } else if isr.$flag().bit_is_set() {
                 break;
             } else {


### PR DESCRIPTION
My last Pullrequest made the Stop bit an error condition for I2C.
When reading though the Stop bit is set because the slave 'sends' the stop bit but this is not actually an error but suspected behaviour. 
Therefore I removed this error condition, maybe we should evaluate checking it only on send?